### PR TITLE
build-essential and qemu-system-x86 do not exist

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -144,7 +144,7 @@ main () {
       $PSEUDO apt-get $YES install $DEB_PKG_GET
     fi
   elif [[ "$NAME" = 'CentOS Linux' ]]; then
-    YUM_PKG_GET='sudo jq git build-essential python-pip golang unzip curl wget parallel ansible rlwrap rsync nmap net-tools qemu-kvm qemu-img virt-manager libvirt libvirt-python libvirt-client virt-install virt-viewer bridge-utils qemu-system-x86'
+    YUM_PKG_GET='sudo jq @development python3-pip golang unzip curl wget parallel ansible rlwrap rsync nmap net-tools qemu-kvm qemu-img virt-manager libvirt libvirt-python3 libvirt-client virt-install virt-viewer bridge-utils'
     if type "yum" &> /dev/null; then
       check_cmd yum
       $PSEUDO yum $YES update


### PR DESCRIPTION
I'm not sure what ``build-essentials`` should contain, but I'm fairly confident that the @development group is a valid replacement. 

``@development`` group also contains Git, so I've removed git as a distinct install target

``qemu-system-x86`` also does not exist, but ``qemu-kvm`` pulls in everything that ought to be necessary (or anyway, everything that CentOS and EPEL provide with "qemu" in the name).

I'm still getting familiar with kubash, so more changes may surface later, but these changes are necessary at least for it to install on CentOS 8+ in the first place.